### PR TITLE
Add support for custom theme configurations

### DIFF
--- a/.changeset/spicy-queens-compete.md
+++ b/.changeset/spicy-queens-compete.md
@@ -1,0 +1,5 @@
+---
+"vitepress-plugin-shiki-twoslash": patch
+---
+
+Added support for custom theme configurations

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -5,7 +5,7 @@ export type TwoslashConfigSettings = Prettify<
   Parameters<typeof transformAttributesToHTML>[3]
 >
 
-export async function withTwoslash(config: UserConfig<DefaultTheme.Config>) {
+export async function withTwoslash<ThemeConfig = DefaultTheme.Config>(config: UserConfig<ThemeConfig>) {
   const { setupForFile, transformAttributesToHTML } = await import(
     'remark-shiki-twoslash'
   )


### PR DESCRIPTION
## Description

The `withTwoSlash` wrapper's `config` argument currently enforces the theme config to be assignable to vitepress' [default theme config interface](https://github.com/vuejs/vitepress/blob/d65afc28733f7edb173b55b43b69e55867ee6b6f/types/default-theme.d.ts#L8). I've added a generic (still defaulting to the default theme interface) so that one may still rely on the `UserConfig` interface along with their own custom theme config. Please let me know if you feel like this would deserve a change on documentation, I wasn't quite sure!

## Additional Information

- [x] I read the [contributing guide](https://github.com/wagmi-dev/vitepress-plugin-shiki-twoslash/blob/main/.github/CONTRIBUTING.md)
- [ ] I added documentation related to the changes made.


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added support for custom theme configurations in `vitepress-plugin-shiki-twoslash`
- Modified the `withTwoslash` function in `src/plugin.ts` to accept a generic `ThemeConfig` parameter

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->